### PR TITLE
게시물 목록 및 상세 얻기 API 작성

### DIFF
--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  class PostsController < ApplicationController
+    respond_to :json
+
+    def index
+      @posts = Post.all
+      respond_with(@posts)
+    end
+  end
+end

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,10 +1,23 @@
 module Api
   class PostsController < ApplicationController
+    rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
     respond_to :json
 
     def index
       @posts = Post.all
       respond_with(@posts)
+    end
+
+    def show
+      @post = Post.find(params[:id])
+      respond_with(@post)
+    end
+
+    private
+
+    def not_found
+      head status: :not_found
     end
   end
 end

--- a/app/views/api/posts/index.json.jbuilder
+++ b/app/views/api/posts/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @posts do |post|
+  json.id post.id
+  json.title post.title
+end

--- a/app/views/api/posts/show.json.jbuilder
+++ b/app/views/api/posts/show.json.jbuilder
@@ -1,0 +1,4 @@
+json.id @post.id
+json.title @post.title
+json.body @post.body
+json.created_at @post.created_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
   resources :posts
+
+  namespace :api do
+    resources :posts, only: :index
+  end
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   # Serve websocket cable requests in-process

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   resources :posts
 
   namespace :api do
-    resources :posts, only: :index
+    resources :posts, only: [:index, :show]
   end
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/test/controllers/api/posts_controller_test.rb
+++ b/test/controllers/api/posts_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module Api
   class PostsControllerTest < ActionDispatch::IntegrationTest
     setup do
-      Post.create!(title: '제목', body: '조...조은 글이다')
+      @post = Post.create!(title: '제목', body: '조...조은 글이다')
     end
 
     test 'GET #index' do
@@ -11,6 +11,18 @@ module Api
       assert_response :success
       assert_includes response.body, '제목'
       assert_not_includes response.body, '조은 글이다'
+    end
+
+    test 'GET #show (200)' do
+      get api_post_url(@post.id), params: { format: :json }
+      assert_response :success
+      assert_includes response.body, '제목'
+      assert_includes response.body, '조은 글이다'
+    end
+
+    test 'GET #show (404)' do
+      get api_post_url('NOT-FOUND'), params: { format: :json }
+      assert_response :not_found
     end
   end
 end

--- a/test/controllers/api/posts_controller_test.rb
+++ b/test/controllers/api/posts_controller_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+module Api
+  class PostsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      Post.create!(title: '제목', body: '조...조은 글이다')
+    end
+
+    test 'GET #index' do
+      get api_posts_url, params: { format: :json }
+      assert_response :success
+      assert_includes response.body, '제목'
+      assert_not_includes response.body, '조은 글이다'
+    end
+  end
+end


### PR DESCRIPTION
1. 게시물 목록 API - `GET /api/posts.json`
2. 게시물 상세 API - `GET /api/posts/<id>.json`

참고: https://gist.github.com/ahastudio/3de871a488ace6bc6f84
